### PR TITLE
v3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [3.3] - 2024-07-05
+### Added
+- an alert to show subject/UUID has been copied
+- new options field for email notification targets (will replace "Your story" email option)
+- temporary storage of individual local_service API results in JSON format (to support debugging)
+
+### Changed
+- admin email target for new email notification targets
+- minor display changes in local_service edit screens
+
 ## [3.2.1] - 2024-05-15
 ### Fixed
 - comment UUID handling

--- a/css/style.css
+++ b/css/style.css
@@ -521,3 +521,10 @@ label[for="hw_services_full_report"]:before {
 	display: inline-block;
 }
 
+/* Styles for copied message */
+#uuid-copied-alert,
+#subject-copied-alert {
+  font-size: 11px;
+  padding: 5px 4px 6px 4px;
+  display: none;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -150,7 +150,8 @@
   width: 290px;
 }
 
-#hw_feedback_field_your_story_email {
+#hw_feedback_field_your_story_email,
+#hw_feedback_field_email_notifications_targets {
 	width: 50%;
 }
 

--- a/feedback-form.php
+++ b/feedback-form.php
@@ -133,9 +133,9 @@ function extend_comment_meta_box($comment)
 
   <?php // older comments have not had a UUID generated (on submission) so we must still show the old id
   if (!empty($uuid)) { ?>
-    <p id="civicrm-uuid-wrapper">CiviCRM UUID: <span id="civicrm-uuid"><?php echo $uuid; ?></span><input type="hidden" value="<?php echo $uuid; ?>" id="civicrm-uuid-field"><button class="ed_button button button-small" type="button" onclick="copy_civicrm_uuid()">Copy</button></p>
+    <p id="civicrm-uuid-wrapper">CiviCRM UUID: <span id="civicrm-uuid"><?php echo $uuid; ?></span><input type="hidden" value="<?php echo $uuid; ?>" id="civicrm-uuid-field"><button class="ed_button button button-small" type="button" onclick="copy_civicrm_uuid()">Copy</button><span id="uuid-copied-alert" class="hw-feedback-alert">Copied!</span></p>
   <?php } else { ?>
-    <p id="civicrm-subject-code-wrapper">CiviCRM Subject Code: <span id="civicrm-subject-code">#w<?php echo $comment->comment_ID; ?></span><input type="hidden" value="#w<?php echo $comment->comment_ID; ?>" id="civicrm-subject-code-field"><button class="ed_button button button-small" type="button" onclick="copy_civicrm_subject_code()">Copy</button></p>
+    <p id="civicrm-subject-code-wrapper">CiviCRM Subject Code: <span id="civicrm-subject-code">#w<?php echo $comment->comment_ID; ?></span><input type="hidden" value="#w<?php echo $comment->comment_ID; ?>" id="civicrm-subject-code-field"><button class="ed_button button button-small" type="button" onclick="copy_civicrm_subject_code()">Copy</button><span id="subject-copied-alert" class="hw-feedback-alert">Copied!</span></p>
   <?php } ?>
   <p>
     <label for="phone">Phone</label>

--- a/feedback-form.php
+++ b/feedback-form.php
@@ -255,10 +255,10 @@ if (is_admin()) {
 
     $plugin_url_path = WP_PLUGIN_URL;
 
-	if( ! empty(get_comment_meta( get_comment_ID(), 'feedback_phone', true ) )) {
-		$commentphone = '<strong>Phone: </strong>' . esc_attr(get_comment_meta(get_comment_ID(), 'feedback_phone', true) ) . '<br/><br/>';
-    $text = $text . $commentphone;
-	}
+    if (!empty(get_comment_meta(get_comment_ID(), 'feedback_phone', true))) {
+      $commentphone = '<strong>Phone: </strong>' . esc_attr(get_comment_meta(get_comment_ID(), 'feedback_phone', true)) . '<br/><br/>';
+      $text = $text . $commentphone;
+    }
 
     /* if( $commentaddress = get_comment_meta( get_comment_ID(), 'feedback_address', true ) ) {
 		$commentaddress = '<strong>Address: </strong>' . esc_attr( $commentaddress ) . '<br/><br/>';

--- a/functions/functions-ods-api-query.php
+++ b/functions/functions-ods-api-query.php
@@ -93,7 +93,8 @@ function hw_feedback_ods_role_code_bootstrap($post_id, $bootstrap_options = 'non
  */
 function hw_feedback_ods_checks($mode)
 {
-
+  // get plugin settings/options
+  $options = get_option('hw_feedback_options');
   /* unhook the hw_feedback_check_cqc_registration_status_single function
   not sure but this might start an infinite loop otherwise
   error_log('hw_feedback: unhook the hw_feedback_check_cqc_registration_status_single function');
@@ -157,7 +158,11 @@ function hw_feedback_ods_checks($mode)
   //add_action( 'updated_post_meta', 'hw_feedback_save_local_services_meta', 10, 4);
 
   // set php mailer variables
-  $to = get_option('admin_email');
+  if ($options['hw_feedback_field_email_notifications_targets'] != "") {
+    $to = $options['hw_feedback_field_email_notifications_targets'];
+  } else {
+    $to = get_option('admin_email');
+  }
   $subject = "Local Services - ODS ". $mode ." (" . parse_url(get_site_url(), PHP_URL_HOST) . ")";
   // set headers to allow HTML
   $headers = array('Content-Type: text/html; charset=UTF-8');

--- a/healthwatchfeedback.php
+++ b/healthwatchfeedback.php
@@ -361,6 +361,20 @@ function hw_feedback_settings_init()
   );
   // Register a new field in the "hw_feedback_section_general_settings" section, inside the "hw_feedback" page.
   add_settings_field(
+    'hw_feedback_field_email_notifications_targets', // As of WP 4.6 this value is used only internally.
+    // Use $args' label_for to populate the id inside the callback.
+    __('Your Story email', 'hw_feedback'),
+    'hw_feedback_field_email_notifications_targets_cb',
+    'hw_feedback',
+    'hw_feedback_section_general_settings',
+    array(
+      'label_for'         => 'hw_feedback_field_email_notifications_targets',
+      'class'             => 'hw_feedback_row',
+      'hw_feedback_custom_data' => 'custom',
+    )
+  );
+  // Register a new field in the "hw_feedback_section_general_settings" section, inside the "hw_feedback" page.
+  add_settings_field(
     'hw_feedback_field_disable_lhw_rating', // As of WP 4.6 this value is used only internally.
     // Use $args' label_for to populate the id inside the callback.
     __('Disable LHW Rating', 'hw_feedback'),
@@ -650,6 +664,28 @@ function hw_feedback_field_your_story_email_cb($args)
   <input type="email" multiple id="<?php echo esc_attr($args['label_for']); ?>" name="hw_feedback_options[<?php echo esc_attr($args['label_for']); ?>]" value="<?php echo isset($options[$args['label_for']]) ? (($options[$args['label_for']])) : (''); ?>">
   <p class="description">
     <?php esc_html_e("E-mail address target(s) for Your Story submissions. You can use more than one address separated by commas (,).", 'hw_feedback'); ?>
+  </p>
+<?php
+}
+
+/**
+ * email_notifications_targets field callback function.
+ *
+ * WordPress has magic interaction with the following keys: label_for, class.
+ * - the "label_for" key value is used for the "for" attribute of the <label>.
+ * - the "class" key value is used for the "class" attribute of the <tr> containing the field.
+ * Note: you can add custom key value pairs to be used inside your callbacks.
+ *
+ * @param array $args
+ */
+function hw_feedback_field_email_notifications_targets_cb($args)
+{
+  // Get the value of the setting we've registered with register_setting()
+  $options = get_option('hw_feedback_options');
+?>
+  <input type="email" multiple id="<?php echo esc_attr($args['label_for']); ?>" name="hw_feedback_options[<?php echo esc_attr($args['label_for']); ?>]" value="<?php echo isset($options[$args['label_for']]) ? (($options[$args['label_for']])) : (''); ?>">
+  <p class="description">
+    <?php esc_html_e("E-mail address target(s) for CQC/ODS notifications. You can use more than one address separated by commas (,).", 'hw_feedback'); ?>
   </p>
 <?php
 }

--- a/healthwatchfeedback.php
+++ b/healthwatchfeedback.php
@@ -298,7 +298,7 @@ function hw_feedback_settings_init()
   // Register a new section in the "hw_feedback" page.
   add_settings_section(
     'hw_feedback_section_comment_notifications_settings',
-    __('Comment Notifications', 'hw_feedback'),
+    __('Provider Comment Notifications', 'hw_feedback'),
     'hw_feedback_section_comment_notifications_settings_callback',
     'hw_feedback'
   );
@@ -321,7 +321,7 @@ function hw_feedback_settings_init()
   add_settings_field(
     'hw_feedback_field_api_subscription_key', // As of WP 4.6 this value is used only internally.
     // Use $args' label_for to populate the id inside the callback.
-    __('Subscription Key', 'hw_feedback'),
+    __('Subscription key', 'hw_feedback'),
     'hw_feedback_field_api_subscription_key_cb',
     'hw_feedback',
     'hw_feedback_section_api_settings',
@@ -335,7 +335,7 @@ function hw_feedback_settings_init()
   add_settings_field(
     'hw_feedback_field_api_cache_path', // As of WP 4.6 this value is used only internally.
     // Use $args' label_for to populate the id inside the callback.
-    __('API Cache Path', 'hw_feedback'),
+    __('API cache path', 'hw_feedback'),
     'hw_feedback_field_api_cache_path_cb',
     'hw_feedback',
     'hw_feedback_section_api_settings',
@@ -363,7 +363,7 @@ function hw_feedback_settings_init()
   add_settings_field(
     'hw_feedback_field_email_notifications_targets', // As of WP 4.6 this value is used only internally.
     // Use $args' label_for to populate the id inside the callback.
-    __('Your Story email', 'hw_feedback'),
+    __('Email notification address(es)', 'hw_feedback'),
     'hw_feedback_field_email_notifications_targets_cb',
     'hw_feedback',
     'hw_feedback_section_general_settings',

--- a/healthwatchfeedback.php
+++ b/healthwatchfeedback.php
@@ -199,7 +199,7 @@ function hw_feedback_activate()
   if (!wp_next_scheduled('hw_feedback_cqc_reg_check_cron_job')) {
     // set the first run 2 minutes from "now"
     wp_schedule_event(time() + 120, 'weekly', 'hw_feedback_cqc_reg_check_cron_job');
-  } 
+  }
   /* Add cron job to run hw_feedback_clean_up_temp
     --------------------------------------------------------- */
   if (!wp_next_scheduled('hw_feedback_clean_up_temp_cron_job')) {
@@ -672,7 +672,7 @@ function hw_feedback_field_disable_lhw_rating_cb($args)
   $options[$args['label_for']] = !empty($options[$args['label_for']]) ? 1 : 0;
 ?>
   <input type="checkbox" id="<?php echo esc_attr($args['label_for']); ?>" name="hw_feedback_options[<?php echo esc_attr($args['label_for']); ?>]" value="1" <?php // checked() as a WordPress function - compares the first two arguments and if identical marks as checked - last arg control whether to echo or not
-                                                                                                                                                                checked(1, $options[$args['label_for']], true) ?>>
+                                                                                                                                                            checked(1, $options[$args['label_for']], true) ?>>
   <p class="description inline-description">
     <?php esc_html_e("Disable Local Healthwatch rating functions? (Does not affect public ratings)", 'hw_feedback'); ?>
   </p>
@@ -742,7 +742,7 @@ function hw_feedback_field_enable_notifications_cb($args)
   $options[$args['label_for']] = !empty($options[$args['label_for']]) ? 1 : 0;
 ?>
   <input type="checkbox" id="<?php echo esc_attr($args['label_for']); ?>" name="hw_feedback_options[<?php echo esc_attr($args['label_for']); ?>]" value="1" <?php // checked() as a WordPress function - compares the first two arguments and if identical marks as checked - last arg control whether to echo or not
-                                                                                                                                                                checked(1, $options[$args['label_for']], true) ?>>
+                                                                                                                                                            checked(1, $options[$args['label_for']], true) ?>>
   <p class="description inline-description">
     <?php esc_html_e("Automatically notify provider, via email, when a new comment is approved", 'hw_feedback'); ?>
   </p>
@@ -768,7 +768,7 @@ function hw_feedback_field_enable_missing_address_reminders_cb($args)
   $options[$args['label_for']] = !empty($options[$args['label_for']]) ? 1 : 0;
 ?>
   <input type="checkbox" id="<?php echo esc_attr($args['label_for']); ?>" name="hw_feedback_options[<?php echo esc_attr($args['label_for']); ?>]" value="1" <?php // checked() as a WordPress function - compares the first two arguments and if identical marks as checked - last arg control whether to echo or not
-                                                                                                                                                                checked(1, $options[$args['label_for']], true) ?>>
+                                                                                                                                                            checked(1, $options[$args['label_for']], true) ?>>
   <p class="description inline-description">
     <?php esc_html_e("Send admin reminders, via email, when a service does not have an email address set", 'hw_feedback'); ?>
   </p>

--- a/healthwatchfeedback.php
+++ b/healthwatchfeedback.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Healthwatch Feedback
-Version: 3.2.1
+Version: 3.3
 Description: Implements a Rate and Review centre on Healthwatch websites. <strong>DO NOT DELETE !</strong>
 Author: Phil Thiselton & Jason King
 */

--- a/includes/dash.php
+++ b/includes/dash.php
@@ -197,7 +197,7 @@ add_action( 'admin_menu', 'hw_feedback_add_menus' );
           // echo the query string (this no longer takes you to the results)
           echo '<p>API Query: https://api.service.cqc.org.uk/public/v1' . $api_response->firstPageUri . '</p>';
           // echo a link to the raw file
-          echo '<p><a href="' . $uploads_folder['baseurl'] . '/' . $api_filename . '" target="_blank">View JSON results</a> | <a href="' . $uploads_folder['baseurl']  . '/' . $api_filename . '" download="' . $uploads_folder['baseurl']  . '/' . $api_filename . '" target="_blank">Download JSON results</a></p>';
+          echo '<p><a href="' . $uploads_folder['baseurl'] . '/' . $api_filename . '" target="_blank">View API results (JSON)</a> | <a href="' . $uploads_folder['baseurl']  . '/' . $api_filename . '" download="' . $uploads_folder['baseurl']  . '/' . $api_filename . '" target="_blank">Download API results (JSON)</a></p>';
           // Convert "JSON object" to array
           $locations = array_values($api_response->locations);
           // count number of locations

--- a/includes/dash.php
+++ b/includes/dash.php
@@ -94,7 +94,7 @@ add_action( 'admin_menu', 'hw_feedback_add_menus' );
 	          </select>
 					</div>
 					<div class="hw-feedback-cqc-import-form-row">
-	          <label for="hw-feedback-form-import-number">Select number of Locations to check/import</label>
+	          <label for="hw-feedback-form-import-number">Select number of Locations to preview/import</label>
 	          <select class="hw-feedback-select" name="hw-feedback-form-import-number" id="hw-feedback-form-import-number">
 	          <?php foreach (array(1, 5, 10, 20, 30, 40, 50) as $option) {
 							if ($import_number && $import_number == $option ) {

--- a/js/copy_civicrm_subject_code.js
+++ b/js/copy_civicrm_subject_code.js
@@ -5,6 +5,10 @@ async function copy_civicrm_uuid() {
   /* Select the text field */
   copyText.select();
 
+  /* show copied message */
+  document.getElementById('uuid-copied-alert').style.display = "inline";
+  document.getElementById('subject-copied-alert').style.display = "inline";
+
    /* Copy the text inside the text field */
   await navigator.clipboard.writeText(copyText.value);
 }

--- a/js/copy_civicrm_subject_code.js
+++ b/js/copy_civicrm_subject_code.js
@@ -5,12 +5,11 @@ async function copy_civicrm_uuid() {
   /* Select the text field */
   copyText.select();
 
+  /* Copy the text inside the text field */
+  await navigator.clipboard.writeText(copyText.value);
+
   /* show copied message */
   document.getElementById('uuid-copied-alert').style.display = "inline";
-  document.getElementById('subject-copied-alert').style.display = "inline";
-
-   /* Copy the text inside the text field */
-  await navigator.clipboard.writeText(copyText.value);
 }
 
 async function copy_civicrm_subject_code() {
@@ -22,6 +21,9 @@ async function copy_civicrm_subject_code() {
 
    /* Copy the text inside the text field */
   await navigator.clipboard.writeText(copyText.value);
+  
+  /* show copied message */
+  document.getElementById('subject-copied-alert').style.display = "inline";
 }
 
 async function hw_feedback_store_values() {

--- a/post-types-taxonomies.php
+++ b/post-types-taxonomies.php
@@ -1194,8 +1194,8 @@ function hw_feedback_approve_comment($new_status, $old_status, $comment) {
           $formatted_message .= $email_footer;
           $sent_provider = wp_mail($to, $subject, stripslashes($formatted_message), $headers);
         } else if ( isset ($options['hw_feedback_field_enable_missing_address_reminders']) ) {
-          if ( $options['hw_feedback_field_your_story_email'] != "") {
-            $to = $options['hw_feedback_field_your_story_email'];
+          if ( $options['hw_feedback_field_email_notifications_targets'] != "") {
+            $to = $options['hw_feedback_field_email_notifications_targets'];
           } else {
             $to = get_option('admin_email');
           }

--- a/post-types-taxonomies.php
+++ b/post-types-taxonomies.php
@@ -1037,6 +1037,8 @@ function hw_feedback_convert_id_to_term_in_query($query) {
 /* 9. Add a function to query CQC reg status and update service
 --------------------------------------------------------- */
 function hw_feedback_check_cqc_registration_status() {
+  // get plugin settings/options
+  $options = get_option('hw_feedback_options');
 
   /* unhook the hw_feedback_check_cqc_registration_status_single function
   not sure but this might start an infinite loop otherwise
@@ -1071,7 +1073,11 @@ function hw_feedback_check_cqc_registration_status() {
   //add_action( 'updated_post_meta', 'hw_feedback_save_local_services_meta', 10, 4);
 
     // set php mailer variables
-    $to = get_option('admin_email');
+    if ($options['hw_feedback_field_email_notifications_targets'] != "") {
+      $to = $options['hw_feedback_field_email_notifications_targets'];
+    } else {
+      $to = get_option('admin_email');
+    }
     $subject = "Local Services - CQC registration updates (". parse_url( get_site_url(), PHP_URL_HOST ) .")";
     // set headers to allow HTML
     $headers = array('Content-Type: text/html; charset=UTF-8');

--- a/post-types-taxonomies.php
+++ b/post-types-taxonomies.php
@@ -1127,7 +1127,8 @@ add_action( 'hw_feedback_clean_up_temp_cron_job', 'hw_feedback_clean_up_temp_upl
 
 // Send an email to a provider when a new comment is APPROVED
 function hw_feedback_approve_comment($new_status, $old_status, $comment) {
-  $options = get_option( 'hw_feedback_options' );
+  // get plugin settings/options
+  $options = get_option('hw_feedback_options');
   // check notifications enabled
   if ( isset( $options['hw_feedback_field_enable_notifications'] ) ) {
     error_log('hw-feedback: notification check');

--- a/post-types-taxonomies.php
+++ b/post-types-taxonomies.php
@@ -619,9 +619,8 @@ function hw_feedback_cpt_fields_meta_box_callback( $post ) {
         echo '<div id="api-output-'.$val.'" class="api-output"><div class="api-output-label">'.$x.':</div><div class="api-output-value">'.$objcqcapiquery->$val.'</div></div>';
       }
     }
-    echo '<div id="api-output-url" class="api-output"><a href="https://www.cqc.org.uk/location/' . $objcqcapiquery->locationId . '" target="_blank">Check this registration on the CQC website</a>';
-    // echo a link to the raw file
-    echo '<p><a href="' . $uploads_folder['baseurl'] . '/' . $api_filename . '" target="_blank">View JSON results</a> | <a href="' . $uploads_folder['baseurl']  . '/' . $api_filename . '" download="' . $uploads_folder['baseurl']  . '/' . $api_filename . '" target="_blank">Download JSON results</a></p></div>';
+    // display useful links to CQC site and copy of the downloaded file
+    echo '<div id="api-output-url" class="api-output"><a href="https://www.cqc.org.uk/location/' . $objcqcapiquery->locationId . '" target="_blank">Check this registration on the CQC website</a> | <a href="' . $uploads_folder['baseurl'] . '/' . $api_filename . '" target="_blank">View API result (JSON)</a> | <a href="' . $uploads_folder['baseurl']  . '/' . $api_filename . '" download="' . $uploads_folder['baseurl']  . '/' . $api_filename . '" target="_blank">Download API result (JSON)</a></div>';
     //echo '<strong>Reg Status: </strong><span class="api-output">' . $objcqcapiquery->registrationStatus . '</span><br />';
     //echo '<strong>Reg Date: </strong><span class="api-output">' . $objcqcapiquery->registrationDate . '</span><br />';
     if ( isset($objcqcapiquery->registrationStatus) && $objcqcapiquery->registrationStatus == 'Deregistered'){ ?>

--- a/post-types-taxonomies.php
+++ b/post-types-taxonomies.php
@@ -1067,8 +1067,8 @@ function hw_feedback_check_cqc_registration_status() {
     endforeach;
 
     error_log('hw-feedback: services check complete!');
-    // restore the hw_feedback_check_cqc_registration_status_single function hook
-    //add_action( 'updated_post_meta', 'hw_feedback_save_local_services_meta', 10, 4);
+  // restore the hw_feedback_check_cqc_registration_status_single function hook
+  //add_action( 'updated_post_meta', 'hw_feedback_save_local_services_meta', 10, 4);
 
     // set php mailer variables
     $to = get_option('admin_email');


### PR DESCRIPTION
### Added
- an alert to show subject/UUID has been copied
- new options field for email notification targets (will replace "Your story" email option)
- temporary storage of individual local_service API results in JSON format (to support debugging)

### Changed
- admin email target for new email notification targets
- minor display changes in local_service edit screens